### PR TITLE
Fix topbanner dark mode

### DIFF
--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -3,10 +3,11 @@ import { css, SerializedStyles } from '@emotion/core';
 
 const bannerLink =
   'https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/';
-const banner: SerializedStyles = css`
+
+const banner: SerializedStyles = css/*scss*/`
   position: relative;
   font-weight: bold;
-  background-color: var(--black3);
+  background-color: var(--color-fill-top-banner);
   font-size: var(--font-size-display2);
   color: var(--color-text-primary);
   border-radius: 5px;
@@ -14,20 +15,17 @@ const banner: SerializedStyles = css`
   padding-top: 5px;
 `;
 
-const bannerCta: SerializedStyles = css`
+const bannerButton: SerializedStyles = css/*scss*/`
+  position: relative;
+  margin-right: var(--space-32);
   border-radius: 5.6rem;
   background: var(--purple5);
-  color: var(--color-fill-top-nav);
-  margin-right: var(--space-32);
-  position: relative;
-`;
-const bannerButtonText: SerializedStyles = css`
   color: var(--color-fill-top-nav);
   line-height: var(--line-height-subheading);
   text-decoration: none;
   font-family: var(--sans);
   font-style: normal;
-  font-weight var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
 `;
 
 /**
@@ -54,11 +52,11 @@ const Banner = (): JSX.Element => {
           paddingBottom: 'var(--space-08)',
         }}
       >
-        <button css={bannerCta} type="button">
-          <a css={bannerButtonText} href={bannerLink}>
-            Blog post
-          </a>
-        </button>
+        <a href={bannerLink}>
+          <button css={bannerButton} type="button">
+              Blog post
+          </button>
+        </a>
         New security releases now available for all release lines
       </p>
     </div>

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -4,7 +4,7 @@ import { css, SerializedStyles } from '@emotion/core';
 const bannerLink =
   'https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/';
 
-const banner: SerializedStyles = css/*scss*/`
+const banner: SerializedStyles = css/* scss */ `
   position: relative;
   font-weight: bold;
   background-color: var(--color-fill-top-banner);
@@ -15,7 +15,7 @@ const banner: SerializedStyles = css/*scss*/`
   padding-top: 5px;
 `;
 
-const bannerButton: SerializedStyles = css/*scss*/`
+const bannerButton: SerializedStyles = css/* scss */ `
   position: relative;
   margin-right: var(--space-32);
   border-radius: 5.6rem;
@@ -54,7 +54,7 @@ const Banner = (): JSX.Element => {
       >
         <a href={bannerLink}>
           <button css={bannerButton} type="button">
-              Blog post
+            Blog post
           </button>
         </a>
         New security releases now available for all release lines

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -95,6 +95,7 @@ body {
     --color-fill-canvas: var(--black1);
     --color-fill-side-nav: var(--black1);
     --color-fill-top-nav: var(--black0);
+    --color-fill-top-banner: #9992;
     --color-fill-action: var(--brand5); /*for actionable elements*/
 
     /* Typography */

--- a/test/components/__snapshots__/banner.test.tsx.snap
+++ b/test/components/__snapshots__/banner.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Tests for Header component renders correctly 1`] = `
   css={
     Object {
       "map": undefined,
-      "name": "1g9ii1p",
+      "name": "433qea",
       "next": undefined,
       "styles": "
   position: relative;
   font-weight: bold;
-  background-color: var(--black3);
+  background-color: var(--color-fill-top-banner);
   font-size: var(--font-size-display2);
   color: var(--color-text-primary);
   border-radius: 5px;
@@ -28,44 +28,34 @@ exports[`Tests for Header component renders correctly 1`] = `
       }
     }
   >
-    <button
-      css={
-        Object {
-          "map": undefined,
-          "name": "ihpspq",
-          "next": undefined,
-          "styles": "
-  border-radius: 5.6rem;
-  background: var(--purple5);
-  color: var(--color-fill-top-nav);
-  margin-right: var(--space-32);
-  position: relative;
-",
-        }
-      }
-      type="button"
+    <a
+      href="https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
     >
-      <a
+      <button
         css={
           Object {
             "map": undefined,
-            "name": "10el6nn",
+            "name": "16knpov",
             "next": undefined,
             "styles": "
+  position: relative;
+  margin-right: var(--space-32);
+  border-radius: 5.6rem;
+  background: var(--purple5);
   color: var(--color-fill-top-nav);
   line-height: var(--line-height-subheading);
   text-decoration: none;
   font-family: var(--sans);
   font-style: normal;
-  font-weight var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
 ",
           }
         }
-        href="https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
+        type="button"
       >
         Blog post
-      </a>
-    </button>
+      </button>
+    </a>
     New security releases now available for all release lines
   </p>
 </div>


### PR DESCRIPTION
## Description

> **Note** This PR branches off #398

Add a new `--color-fill-top-banner` custom property in [tokens.css](https://github.com/SMotaal/nodejs.dev/blob/fix-topbanner-dark-mode/src/styles/tokens.css#L98) using alpha blending to match light and dark.

This also restructures the pill-button as `<a><button>` instead of `<button><a>` to avoid the clashing hover color of the text. As a result, it was possible to refactor its styling as a single `bannerButton` instead of `bannerCta` and `bannerButtonText`.

## Screen Shots

<img width="1392" alt="Screen Shot 2020-02-29 at 1 35 24 PM" src="https://user-images.githubusercontent.com/849613/75613221-345ba800-5af9-11ea-9073-b56a4c9fcd29.png">
<img width="1392" alt="Screen Shot 2020-02-29 at 1 35 29 PM" src="https://user-images.githubusercontent.com/849613/75613229-37ef2f00-5af9-11ea-82a9-19dcdc3666c8.png">


## Live Build

**`Feb29`** https://storage.googleapis.com/staging.nodejs.dev/a003e53/index.html


## Related Issues

#398